### PR TITLE
Add initial spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>
+      Digital Credentials API
+    </title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class=
+    "remove"></script>
+    <script class="remove">
+    "use strict";
+    // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
+    var respecConfig = {
+      github: "WICG/digital-credentials",
+      editors: [
+        {
+          name: "Marcos Caceres",
+          email: "marcosc@apple.com",
+          company: "Apple Inc.",
+          companyURL: "https://apple.com",
+        },
+        // Add additional editors here.
+        // https://github.com/w3c/respec/wiki/editors
+      ],
+      shortName: "digital-credentials",
+      specStatus: "CG-DRAFT",
+      group: "wicg",
+      localBiblio: {
+        "ISO-18013-5": {
+          title: "ISO/IEC 18013-5:2021 Personal identification — ISO-compliant driving licence — Part 5: Mobile driving licence (mDL) application",
+          href: "https://www.iso.org/standard/69084.html",
+          publisher: "ISO",
+          date: "2021-09",
+          status: "Published",
+          seriesInfo: "ISO/IEC 18013-5:2021",
+        },
+      },
+      xref: {
+        profile: "web-platform",
+      },
+    };
+    </script>
+  </head>
+  <body data-cite="credential-management-1 WebCryptoAPI">
+    <section id="abstract">
+      <p>
+        This document standardizes an API solution for requesting digital
+        identity credentials (e.g., a drivers license) or verifying some aspect
+        of a digital identity credential (e.g., proof of age). The API builds
+        on the [[[credential-management-1]]] as a means to request a digital
+        credential from the user agent or underlying platform.
+      </p>
+    </section>
+    <section id="sotd">
+      <p>
+        This is an unofficial proposal.
+      </p>
+    </section>
+    <h2>
+      Introduction
+    </h2>
+    <p>
+      TBW
+    </p>
+    <h2>
+      Model
+    </h2>
+    <dl class="definitions">
+      <dt>
+        <dfn>digital identity credential</dfn>
+      </dt>
+      <dd>
+        A digital identity credential is a digital representation of a physical
+        identity credential (e.g., a drivers license, passport, etc). A digital
+        identity credential represents a set of claims about the subject of the
+        credential (e.g., the holder of the credential). A digital identity
+        credential is issued by an issuer (e.g., a government agency).
+      </dd>
+      <dt>
+        <dfn>Identity credential provider</dfn>
+      </dt>
+      <dd>
+        <p>
+          A credential provider is a an application or OS-level service that
+          presents UI to the user to request a digital identity credentia For
+          example,s a credential provider could be a mobile wallet application
+          that requests a mobile drivers license from the user.
+        </p>
+        <p>
+          A credential provider is responsible for presenting the user with a
+          list of [=digital credential/request protocol=] specific providers
+          (e.g., a list of mobile drivers license or applications that hold
+          driver's licenses).
+        </p>
+      </dd>
+      <dt>
+        <dfn for="digital identity">request protocol</dfn>
+      </dt>
+      <dd>
+        The request protocol is a standardized format/structure to [=request
+        digital identity credentials=]. For example, a request protocol could
+        be a <a>"mdoc"</a> for mobile drivers licenses as per [[?ISO-18013-5]].
+      </dd>
+    </dl>
+    <h2>
+      Scope
+    </h2>
+    <p>
+      The following is in is scope for the this specification:
+    </p>
+    <ul>
+      <li>Requesting a [=digital identity credentials=].
+      </li>
+    </ul>
+    <p>
+      The following is out of scope
+    </p>
+    <ul>
+      <li>Creating, updating, deleting, or otherwise managing [=digital
+      identity credentials=].
+      </li>
+    </ul>
+    <h2>
+      Extensions to the `CredentialsContainer` interface
+    </h2>
+    <pre class="idl">
+    partial interface CredentialsContainer {
+      Promise&lt;DigitalCredential&gt; requestIdentity(IdentityRequestOptions options);
+    };
+    </pre>
+    <h3>
+      The `requestIdentity()` method
+    </h3>
+    <p data-dfn-for="CredentialsContainer">
+      When the <dfn>requestIdentity()</dfn> method is called, the user agent
+      MUST run the [=request digital identity credentials=] steps.
+    </p>
+    <h2>
+      The `IdentityRequestOptions` dictionary
+    </h2>
+    <p>
+      The {{IdentityRequestOptions}} dictionary is used to specify options when
+      requesting a digital identity credential.
+    </p>
+    <pre class="idl">
+    dictionary IdentityRequestOptions {
+      AbortSignal signal;
+      required sequence&lt;IdentityRequestProvider&gt; providers;
+    };
+    </pre>
+    <p>
+      The <dfn data-dfn-for="IdentityRequestOptions">providers</dfn> member is
+      a sequence of [=digital credential/request protocol=] specific providers.
+    </p>
+    <h3>
+      The `signal` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="IdentityRequestOptions">signal</dfn> member is an
+      {{AbortSignal}} that allows the caller to abort an ongoing [=request
+      digital identity credentials=].
+    </p>
+    <h2>
+      The `IdentityRequestProvider` dictionary
+    </h2>
+    <p>
+      The {{IdentityRequestProvider}} dictionary is used to specify a [=digital
+      credential/request protocol=] specific provider, while also handling
+      cryptographic requirements.
+    </p>
+    <pre class="idl">
+    dictionary IdentityRequestProvider {
+      required DOMString protocol;
+      required ArrayBuffer request;
+      required CryptoKey publicKey;
+    };
+    </pre>
+    <h3>
+      The `protocol` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="IdentityRequestProvider">protocol</dfn> member
+      denotes the [=digital credential/request protocol=] when requesting an
+      identify credential via {{CredentialsContainer/requestIdentity()}}.
+    </p>
+    <p>
+      The {{IdentityRequestProvider/protocol}} member's value is be one of the
+      keys defined in [[[#protocol-registry]]].
+    </p>
+    <h3>
+      The `request` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="IdentityRequestProvider">request</dfn> member is
+      the request to be sent to the [=identity credential provider=].
+    </p>
+    <h3>
+      The `publicKey` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="IdentityRequestProvider">publicKey</dfn> member is
+      the public key of the [=identity credential provider=].
+    </p>
+    <h2>
+      Requesting a digital identity credential
+    </h2>
+    <p>
+      The following steps are taken to <dfn>request digital identity
+      credentials</dfn>, with {{IdentityRequestOptions}} |options|:
+    </p>
+    <ol>
+      <li>Let |promise| be [=a new promise=].
+      </li>
+      <li>Return |promise| and continue running the following steps [=in
+      parallel=].
+      </li>
+      <li>For each |provider:IdentityRequestProvider| of |options|'s
+      {{IdentityRequestOptions/providers}}.
+        <ol>
+          <li>[=verify the public key=] of |provider|.
+          </li>
+        </ol>
+      </li>
+      <li>...present [=identity credential provider=] to user.
+      </li>
+    </ol>
+    <h2>
+      The `DigitalCredential` interface
+    </h2>
+    <p>
+      The {{DigitalCredential}} interface represents a [=digital identity
+      credential=].
+    </p>
+    <pre class="idl">
+    [Exposed=Window, SecureContext]
+    interface DigitalCredential : Credential {
+      readonly attribute DOMString protocol;
+      readonly attribute ArrayBuffer data;
+    };
+    </pre>
+    <h3>
+      The `protocol` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="DigitalCredential">protocol</dfn> member is the
+      [=digital credential/request protocol=] that was used to request the
+      credential.
+    </p>
+    <h3>
+      The `data` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="DigitalCredential">data</dfn> member is the
+      credential's encrypted data.
+    </p>
+    <h2>
+      Public key verification
+    </h2>
+    <p>
+      The following steps are taken to <dfn>verify the public key</dfn> of a
+      [=identity credential provider=], with {{CryptoKey}} |key|:
+    </p>
+    <ol>
+      <li>...restrictions on type, format, and usage of |key|...
+      </li>
+    </ol>
+    <h2 id="protocol-registry">
+      Identity Request Protocols Registry
+    </h2>
+    <p>
+      The following is the initial registry of [=digital credential/request
+      protocols=] that are supported by this specification.
+    </p>
+    <p>
+      User agents MUST support the following [=digital credential/request
+      protocols=]:
+    </p>
+    <table class="data">
+      <thead>
+        <tr>
+          <th>
+            Protocol identifier
+          </th>
+          <th>
+            Description
+          </th>
+          <th>
+            Specification
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <code><dfn>"mdoc"</dfn></code>
+          </td>
+          <td>
+            A mobile driving license (mDL) request.
+          </td>
+          <td>
+            [[ISO-18013-5]]
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <section id="conformance"></section>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -43,9 +43,14 @@
     <section id="abstract">
       <p>
         This document specifies an API to allow user agents to mediate access
-        to, and representing, a verifiably-issued digital identity (e.g. a government issued digital driver's license, a passport issued by a country, a student card or diploma issued by a university, an employee card issued by a company, a passenger's boarding pass issued by an airline, a profile issued by an online social network, membership cards, vaccination records, etc)  
-        license). The API builds on [[[credential-management-1]]] as a means to
-        request a digital identity from the user agent or underlying platform.
+        to, and representing, a verifiably-issued digital identity (e.g. a
+        government issued digital driver's license, a passport issued by a
+        country, a student card or diploma issued by a university, an employee
+        card issued by a company, a passenger's boarding pass issued by an
+        airline, a profile issued by an online social network, membership
+        cards, vaccination records, etc) license). The API builds on
+        [[[credential-management-1]]] as a means to request a digital identity
+        from the user agent or underlying platform.
       </p>
     </section>
     <section id="sotd">
@@ -69,8 +74,10 @@
       <dd>
         <p>
           A specialized type of [=credential=] corresponding to the real-world
-          identity of a person enabling a [=verifier=] to make authentication
-          decisions based on identity statements verifiably made by an [=issuer=].
+          identity of a person enabling a <a data-cite=
+          "vc-data-model-2.0#dfn-verifier">verifier</a> to make authentication
+          decisions based on identity statements verifiably made by an
+          [=issuer=].
         </p>
         <aside class="Note">
           [=Credentials=] that are classified as [=identity credentials=]
@@ -198,7 +205,8 @@
     </p>
     <p>
       The {{IdentityRequestProvider/protocol}} member's value is be one of the
-      well-defined keys defined in [[[#protocol-registry]]] or any other custom one.
+      well-defined keys defined in [[[#protocol-registry]]] or any other custom
+      one.
     </p>
     <h3>
       The `request` member

--- a/index.html
+++ b/index.html
@@ -44,10 +44,10 @@
   <body data-cite="credential-management-1 WebCryptoAPI">
     <section id="abstract">
       <p>
-        This document specifies an API solution for requesting digital
-        identity credentials (e.g. a drivers license) or verifying some aspect
-        of a digital identity credential (e.g., proof of age). The API builds
-        on the [[[credential-management-1]]] as a means to request a digital
+        This document specifies an API solution for requesting digital identity
+        credentials (e.g. a driver's license) or verifying some aspect of a
+        digital identity credential (e.g., proof of age). The API builds on the
+        [[[credential-management-1]]] as a means to request a digital
         credential from the user agent or underlying platform.
       </p>
     </section>
@@ -71,10 +71,11 @@
       </dt>
       <dd>
         A digital identity credential is a digital representation of a physical
-        identity credential (e.g., a drivers license, passport, etc). A digital
-        identity credential represents a set of claims about the subject of the
-        credential (e.g., the holder of the credential). A digital identity
-        credential is issued by an issuer (e.g., a government agency).
+        identity credential (e.g., a driver's license, passport, etc). A
+        digital identity credential represents a set of claims about the
+        subject of the credential (e.g., the holder of the credential). A
+        digital identity credential is issued by an issuer (e.g., a government
+        agency).
       </dd>
       <dt>
         <dfn>Identity credential provider</dfn>
@@ -84,12 +85,12 @@
           A credential provider is a an application or OS-level service that
           presents UI to the user to request a digital identity credentia For
           example,s a credential provider could be a mobile wallet application
-          that requests a mobile drivers license from the user.
+          that requests a mobile driver's license from the user.
         </p>
         <p>
           A credential provider is responsible for presenting the user with a
           list of [=digital credential/request protocol=] specific providers
-          (e.g., a list of mobile drivers license or applications that hold
+          (e.g., a list of mobile driver's license or applications that hold
           driver's licenses).
         </p>
       </dd>
@@ -99,7 +100,8 @@
       <dd>
         The request protocol is a standardized format/structure to [=request
         digital identity credentials=]. For example, a request protocol could
-        be a <a>"mdoc"</a> for mobile drivers licenses as per [[?ISO-18013-5]].
+        be a <a>"mdoc"</a> for mobile driver's licenses as per
+        [[?ISO-18013-5]].
       </dd>
     </dl>
     <h2>

--- a/index.html
+++ b/index.html
@@ -83,14 +83,14 @@
         <p>
           A credential provider is a an application or OS-level service that
           presents UI to the user to request a [=digital credential=]. For
-          example, a credential provider could be a wallet application
-          that requests a driver's license from the user.
+          example, a credential provider could be a wallet application that
+          requests a driver's license from the user.
         </p>
         <p>
           A credential provider is responsible for presenting the user with a
           list of [=digital credential/request protocol=] specific providers
-          (e.g., a list of driver's license or applications that hold
-          driver's licenses).
+          (e.g., a list of driver's license or applications that hold driver's
+          licenses).
         </p>
       </dd>
       <dt>

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
     [Exposed=Window, SecureContext]
     interface DigitalIdentity : Identity {
       readonly attribute DOMString protocol;
-      readonly attribute ArrayBuffer data;
+      readonly attribute DOMString data;
     };
     </pre>
     <h3>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
   <body data-cite="credential-management-1 WebCryptoAPI">
     <section id="abstract">
       <p>
-        This document standardizes an API solution for requesting digital
+        This document specifies an API solution for requesting digital
         identity credentials (e.g., a drivers license) or verifying some aspect
         of a digital identity credential (e.g., proof of age). The API builds
         on the [[[credential-management-1]]] as a means to request a digital

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>
-      Digital Credentials API
+      Digital Credentials
     </title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class=
     "remove"></script>

--- a/index.html
+++ b/index.html
@@ -83,13 +83,13 @@
         <p>
           A credential provider is a an application or OS-level service that
           presents UI to the user to request a [=digital credential=]. For
-          example, a credential provider could be a mobile wallet application
-          that requests a mobile driver's license from the user.
+          example, a credential provider could be a wallet application
+          that requests a driver's license from the user.
         </p>
         <p>
           A credential provider is responsible for presenting the user with a
           list of [=digital credential/request protocol=] specific providers
-          (e.g., a list of mobile driver's license or applications that hold
+          (e.g., a list of driver's license or applications that hold
           driver's licenses).
         </p>
       </dd>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>
-      Digital Credentials
+      Digital Identities
     </title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class=
     "remove"></script>
@@ -19,10 +19,16 @@
           company: "Apple Inc.",
           companyURL: "https://apple.com",
         },
+        {
+          name: "Sam Goto",
+          email: "goto@google.com",
+          company: "Google Inc.",
+          companyURL: "https://google.com",
+        },
         // Add additional editors here.
         // https://github.com/w3c/respec/wiki/editors
       ],
-      shortName: "digital-credentials",
+      shortName: "digital-identity",
       specStatus: "CG-DRAFT",
       group: "wicg",
       localBiblio: {
@@ -44,11 +50,10 @@
   <body data-cite="credential-management-1 WebCryptoAPI">
     <section id="abstract">
       <p>
-        This document specifies an API solution for requesting digital
-        credentials (e.g. a driver's license) or verifying some aspect of a
-        digital credential (e.g., proof of age). The API builds on the
-        [[[credential-management-1]]] as a means to request a digital
-        credential from the user agent or underlying platform.
+        This document specifies an API to allow user agents to mediate access
+        to, and representing, a digital identity (e.g. a digital driver's
+        license). The API builds on [[[credential-management-1]]] as a means to
+        request a digital identity from the user agent or underlying platform.
       </p>
     </section>
     <section id="sotd">
@@ -65,115 +70,123 @@
     <h2>
       Model
     </h2>
-    <dl class="definitions">
+    <dl class="definitions" data-sort="">
       <dt>
-        <dfn>Digital credential</dfn>
-      </dt>
-      <dd>
-        A digital credential is a digital representation of a physical identity
-        credential (e.g., a driver's license, passport, etc). A digital
-        identity credential represents a set of claims about the subject of the
-        credential (e.g., the holder of the credential). A digital identity
-        credential is issued by an issuer (e.g., a government agency).
-      </dd>
-      <dt>
-        <dfn>Credential provider</dfn>
+        <dfn>Identity credential</dfn>
       </dt>
       <dd>
         <p>
-          A credential provider is a an application or OS-level service that
-          presents UI to the user to request a [=digital credential=]. For
-          example, a credential provider could be a wallet application that
-          requests a driver's license from the user.
+          A specialized type of [=credential=] corresponding to the real-world
+          identity of a person enabling developers to make authentication
+          decisions based on verified identity information.
         </p>
-        <p>
-          A credential provider is responsible for presenting the user with a
-          list of [=digital credential/request protocol=] specific providers
-          (e.g., a list of driver's license or applications that hold driver's
-          licenses).
-        </p>
+        <aside class="Note">
+          [=Credentials=] that are classified as [=identity credentials=]
+          always inherit from the {{Identity}} interface.
+        </aside>
       </dd>
       <dt>
-        <dfn for="digital credential">Request protocol</dfn>
+        <dfn data-local-lt="digital identities">Digital identity</dfn>
       </dt>
       <dd>
-        The request protocol is a standardized format/structure to [=request a
-        digital credential=]. For example, a request protocol could be a
-        `"some-format"` to request a driver's licenses.
+        <p>
+          A digital representation of an [=identity credential=], such as a
+          digital driver's license or passport, embodying verifiable claims
+          about an individual's identity. Issued by a trusted [=digital
+          identity/issuer=], it enables authenticated interactions.
+        </p>
+        <aside class="Note">
+          [=Digital identities=] are represented as {{DigitalIdentity}}
+          instances.
+        </aside>
+      </dd>
+      <dt>
+        <dfn>Identity credential chooser</dfn>
+      </dt>
+      <dd>
+        An application or service that provides a user interface for selecting
+        and/or querying a [=digital identity=], such as a digital wallet that
+        manages various identity documents and credentials.
+      </dd>
+      <dt>
+        <dfn data-for="digital identity">Request protocol</dfn>
+      </dt>
+      <dd>
+        A standardized format for requesting a [=digital identity=], designed
+        to ensure the secure, private, and interoperable exchange of identity
+        information. See [[#protocol-registry]].
+      </dd>
+      <dt>
+        <dfn data-for="Digital identity">Issuer</dfn>
+      </dt>
+      <dd>
+        The entity that issues a [=digital identity=], such as a government
+        agency or certified organizations.
       </dd>
     </dl>
     <h2>
       Scope
     </h2>
     <p>
-      The following is in is scope for the this specification:
+      The following items are within the scope of this specification:
     </p>
     <ul>
-      <li>Requesting a [=digital credentials=].
+      <li>Requesting a [=digital identity=], including mechanisms for secure
+      presentation.
       </li>
     </ul>
     <p>
-      The following is out of scope
+      The following items are out of scope:
     </p>
     <ul>
-      <li>Creating, updating, deleting, or otherwise managing [=digital
-      credentials=].
+      <li>Enrollment process for establishing a [=digital identity=].
+      </li>
+      <li>UI/UX considerations, with the exception of privacy considerations,
+      which are addressed to ensure the protection of user data during the
+      request process.
       </li>
     </ul>
     <h2>
-      Extensions to Credential Management API
+      Extensions to the `Navigator` interface
     </h2>
-    <p>
-      ...coming soon...
-    </p>
-    <h3>
-      Extensions to the `CredentialsContainer` interface
-    </h3>
     <pre class="idl">
-    partial interface CredentialsContainer {
-      Promise&lt;DigitalCredential&gt; requestIdentity(DigitalCredentialRequestOptions options);
+    partial interface Navigator {
+      [SecureContext, SameObject] readonly attribute CredentialsContainer identity;
     };
     </pre>
     <h3>
-      The `requestIdentity()` method
+      The `identity` attribute
     </h3>
-    <p data-dfn-for="CredentialsContainer">
-      When the <dfn>requestIdentity()</dfn> method is called, the user agent
-      MUST run the [=request a digital credential=] steps.
+    <p data-dfn-for="Navigator">
+      The <dfn>identity</dfn> attribute provides access to the the underlying
+      {{CredentialsContainer}} for managing [=identity credentials=].
     </p>
-    <aside class="issue" data-number="61"></aside>
+    <h3>
+      Extensions to Credential Management API
+    </h3>
+    <aside class="issue" data-number="65"></aside>
     <h2>
-      The `DigitalCredentialRequestOptions` dictionary
+      The `DigitalIdentityRequestOptions` dictionary
     </h2>
-    <p>
-      The {{DigitalCredentialRequestOptions}} dictionary is used to specify
-      options when requesting a digital identity credential.
-    </p>
     <pre class="idl">
-    dictionary DigitalCredentialRequestOptions {
-      AbortSignal signal;
+    dictionary DigitalIdentityRequestOptions : CredentialRequestOptions {
       required sequence&lt;IdentityRequestProvider&gt; providers;
     };
     </pre>
-    <p>
-      The <dfn data-dfn-for="DigitalCredentialRequestOptions">providers</dfn>
-      member is a sequence of [=digital credential/request protocol=] specific
-      providers.
-    </p>
     <h3>
-      The `signal` member
+      The `providers` member
     </h3>
     <p>
-      The <dfn data-dfn-for="DigitalCredentialRequestOptions">signal</dfn>
-      member is an {{AbortSignal}} that allows the caller to abort an ongoing
-      [=request a digital credential=].
+      The <dfn data-dfn-for="DigitalIdentityRequestOptions">providers</dfn>
+      member is a sequence of [=digital identity/request protocol=] specific
+      providers.
     </p>
     <h2>
       The `IdentityRequestProvider` dictionary
     </h2>
     <p>
       The {{IdentityRequestProvider}} dictionary is used to specify a [=digital
-      credential/request protocol=] specific provider, while also handling
+      identity/request protocol=] specific provider, while also handling
       cryptographic requirements.
     </p>
     <pre class="idl">
@@ -187,8 +200,8 @@
     </h3>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">protocol</dfn> member
-      denotes the [=digital credential/request protocol=] when requesting an
-      identify credential via {{CredentialsContainer/requestIdentity()}}.
+      denotes the [=digital identity/request protocol=] when requesting an
+      identify credential.
     </p>
     <p>
       The {{IdentityRequestProvider/protocol}} member's value is be one of the
@@ -199,40 +212,30 @@
     </h3>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">request</dfn> member is
-      the request to be sent to the [=credential provider=].
+      the request to be sent to the [=identity credential chooser=].
     </p>
     <h2>
-      Requesting a digital identity credential
+      The `Identity` interface
     </h2>
     <p>
-      The following steps are taken to <dfn>request a digital credential</dfn>,
-      with {{DigitalCredentialRequestOptions}} |options|:
+      The <dfn>Identity</dfn> interface represents an [=identity credential=].
     </p>
-    <ol>
-      <li>Let |promise| be [=a new promise=].
-      </li>
-      <li>Return |promise| and continue running the following steps [=in
-      parallel=].
-      </li>
-      <li>For each |provider:IdentityRequestProvider| of |options|'s
-      {{DigitalCredentialRequestOptions/providers}}.
-        <ol>
-          <li>...process provider...
-          </li>
-        </ol>
-      </li>
-      <li>...present [=credential provider=] to user.
-      </li>
-    </ol>
+    <pre class="idl">
+      [Exposed=Window]
+      interface Identity : Credential {
+        // Future things...
+      };
+    </pre>
     <h2>
-      The `DigitalCredential` interface
+      The `DigitalIdentity` interface
     </h2>
     <p>
-      The {{DigitalCredential}} interface represents a [=digital credential=].
+      The <dfn>DigitalIdentity</dfn> interface represents a [=digital
+      identity=].
     </p>
     <pre class="idl">
     [Exposed=Window, SecureContext]
-    interface DigitalCredential : Credential {
+    interface DigitalIdentity : Identity {
       readonly attribute DOMString protocol;
       readonly attribute ArrayBuffer data;
     };
@@ -241,27 +244,22 @@
       The `protocol` member
     </h3>
     <p>
-      The <dfn data-dfn-for="DigitalCredential">protocol</dfn> member is the
-      [=digital credential/request protocol=] that was used to request the
-      credential.
+      The <dfn data-dfn-for="DigitalIdentity">protocol</dfn> member is the
+      [=digital identity/request protocol=] that was used to request the
+      [=identity credential=].
     </p>
     <h3>
       The `data` member
     </h3>
     <p>
-      The <dfn data-dfn-for="DigitalCredential">data</dfn> member is the
+      The <dfn data-dfn-for="DigitalIdentity">data</dfn> member is the
       credential's encrypted data.
     </p>
-    <ol>
-      <li>
-        <aside class="issue" data-number="56"></aside>
-      </li>
-    </ol>
     <h2 id="protocol-registry">
-      Registry of protocols for requesting Digital Credential
+      Registry of protocols for requesting digital identity
     </h2>
     <p>
-      The following is the registry of [=digital credential/request protocols=]
+      The following is the registry of [=digital identity/request protocols=]
       that are supported by this specification.
     </p>
     <p class="note" title="Official Registry" data-cite="w3c-process">
@@ -276,13 +274,12 @@
     </p>
     <aside class="issue" data-number="58"></aside>
     <p>
-      [=User agents=] MUST support the following [=digital credential/request
+      [=User agents=] MUST support the following [=digital identity/request
       protocols=]:
     </p>
     <table class="data">
       <caption>
-        Table of officially registered [=digital credential/request
-        protocols=].
+        Table of officially registered [=digital identity/request protocols=].
       </caption>
       <thead>
         <tr>

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
       The following items are out of scope:
     </p>
     <ul>
-      <li> Issuance process for establishing a [=digital identity=].
+      <li>Issuance process for establishing a [=digital identity=].
       </li>
       <li>UI/UX considerations, with the exception of privacy considerations,
       which are addressed to ensure the protection of user data during the

--- a/index.html
+++ b/index.html
@@ -131,9 +131,7 @@
     </h3>
     <pre class="idl">
     partial interface CredentialsContainer {
-      Promise&lt;DigitalCredential&gt; requestIdentity(
-        DigitalCredentialRequestOptions options
-      );
+      Promise&lt;DigitalCredential&gt; requestIdentity(DigitalCredentialRequestOptions options);
     };
     </pre>
     <h3>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
     </h2>
     <dl class="definitions">
       <dt>
-        <dfn>digital credential</dfn>
+        <dfn>Digital credential</dfn>
       </dt>
       <dd>
         A digital credential is a digital representation of a physical identity
@@ -94,7 +94,7 @@
         </p>
       </dd>
       <dt>
-        <dfn for="digital credential">request protocol</dfn>
+        <dfn for="digital credential">Request protocol</dfn>
       </dt>
       <dd>
         The request protocol is a standardized format/structure to [=request a
@@ -141,6 +141,7 @@
       When the <dfn>requestIdentity()</dfn> method is called, the user agent
       MUST run the [=request a digital credential=] steps.
     </p>
+    <aside class="issue" data-number="61"></aside>
     <h2>
       The `DigitalCredentialRequestOptions` dictionary
     </h2>
@@ -204,6 +205,7 @@
     <h3>
       The `publicKey` member
     </h3>
+    <aside class="issue" data-number="49"></aside>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">publicKey</dfn> member is
       the public key of the [=credential provider=].
@@ -289,16 +291,14 @@
       To be included in the registry...
     </p>
     <aside class="issue" data-number="58"></aside>
-    <h3>
-
-    </h3>
     <p>
       [=User agents=] MUST support the following [=digital credential/request
       protocols=]:
     </p>
     <table class="data">
       <caption>
-        Table of officially registered [=digital credential/request protocols=].
+        Table of officially registered [=digital credential/request
+        protocols=].
       </caption>
       <thead>
         <tr>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
     </h2>
     <pre class="idl">
     partial interface CredentialsContainer {
-      Promise&lt;DigitalCredential&gt; requestIdentity(IdentityRequestOptions options);
+      Promise&lt;DigitalCredential&gt; requestIdentity(DigitalCredentialRequestOptions options);
     };
     </pre>
     <h3>

--- a/index.html
+++ b/index.html
@@ -158,11 +158,11 @@
     </h3>
     <aside class="issue" data-number="65"></aside>
     <h2>
-      The `DigitalIdentityRequestOptions` dictionary
+       Extensions to `CredentialRequestOptions` dictionary
     </h2>
     <pre class="idl">
-    dictionary DigitalIdentityRequestOptions : CredentialRequestOptions {
-      required sequence&lt;IdentityRequestProvider&gt; providers;
+    partial dictionary CredentialRequestOptions {
+     sequence&lt;IdentityRequestProvider&gt; providers;
     };
     </pre>
     <h3>

--- a/index.html
+++ b/index.html
@@ -39,11 +39,11 @@
     };
     </script>
   </head>
-  <body data-cite="credential-management-1 WebCryptoAPI">
+  <body data-cite="credential-management-1">
     <section id="abstract">
       <p>
         This document specifies an API to allow user agents to mediate access
-        to, and representing, a digital identity (e.g. a digital driver's
+        to, and representing, a verifiably-issued digital identity (e.g. a government issued digital driver's license, a passport issued by a country, a student card or diploma issued by a university, an employee card issued by a company, a passenger's boarding pass issued by an airline, a profile issued by an online social network, membership cards, vaccination records, etc)  
         license). The API builds on [[[credential-management-1]]] as a means to
         request a digital identity from the user agent or underlying platform.
       </p>
@@ -70,7 +70,7 @@
         <p>
           A specialized type of [=credential=] corresponding to the real-world
           identity of a person enabling developers to make authentication
-          decisions based on verified identity information.
+          decisions based on identity statements verifiably made by an [=issuer=].
         </p>
         <aside class="Note">
           [=Credentials=] that are classified as [=identity credentials=]
@@ -185,7 +185,7 @@
     <pre class="idl">
     dictionary IdentityRequestProvider {
       required DOMString protocol;
-      required ArrayBuffer request;
+      required DOMString request;
     };
     </pre>
     <h3>
@@ -198,7 +198,7 @@
     </p>
     <p>
       The {{IdentityRequestProvider/protocol}} member's value is be one of the
-      keys defined in [[[#protocol-registry]]].
+      well-defined keys defined in [[[#protocol-registry]]] or any other custom one.
     </p>
     <h3>
       The `request` member

--- a/index.html
+++ b/index.html
@@ -32,14 +32,6 @@
       specStatus: "CG-DRAFT",
       group: "wicg",
       localBiblio: {
-        "ISO-18013-5": {
-          title: "ISO/IEC 18013-5:2021 Personal identification — ISO-compliant driving licence — Part 5: Mobile driving licence (mDL) application",
-          href: "https://www.iso.org/standard/69084.html",
-          publisher: "ISO",
-          date: "2021-09",
-          status: "Published",
-          seriesInfo: "ISO/IEC 18013-5:2021",
-        },
       },
       xref: {
         profile: "web-platform",

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
       The following items are out of scope:
     </p>
     <ul>
-      <li>Enrollment process for establishing a [=digital identity=].
+      <li> Issuance process for establishing a [=digital identity=].
       </li>
       <li>UI/UX considerations, with the exception of privacy considerations,
       which are addressed to ensure the protection of user data during the

--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
   <body data-cite="credential-management-1 WebCryptoAPI">
     <section id="abstract">
       <p>
-        This document specifies an API solution for requesting digital identity
+        This document specifies an API solution for requesting digital
         credentials (e.g. a driver's license) or verifying some aspect of a
-        digital identity credential (e.g., proof of age). The API builds on the
+        digital credential (e.g., proof of age). The API builds on the
         [[[credential-management-1]]] as a means to request a digital
         credential from the user agent or underlying platform.
       </p>
@@ -67,23 +67,22 @@
     </h2>
     <dl class="definitions">
       <dt>
-        <dfn>digital identity credential</dfn>
+        <dfn>digital credential</dfn>
       </dt>
       <dd>
-        A digital identity credential is a digital representation of a physical
-        identity credential (e.g., a driver's license, passport, etc). A
-        digital identity credential represents a set of claims about the
-        subject of the credential (e.g., the holder of the credential). A
-        digital identity credential is issued by an issuer (e.g., a government
-        agency).
+        A digital credential is a digital representation of a physical identity
+        credential (e.g., a driver's license, passport, etc). A digital
+        identity credential represents a set of claims about the subject of the
+        credential (e.g., the holder of the credential). A digital identity
+        credential is issued by an issuer (e.g., a government agency).
       </dd>
       <dt>
-        <dfn>Identity credential provider</dfn>
+        <dfn>Credential provider</dfn>
       </dt>
       <dd>
         <p>
           A credential provider is a an application or OS-level service that
-          presents UI to the user to request a digital identity credentia For
+          presents UI to the user to request a [=digital credential=]. For
           example,s a credential provider could be a mobile wallet application
           that requests a mobile driver's license from the user.
         </p>
@@ -95,13 +94,12 @@
         </p>
       </dd>
       <dt>
-        <dfn for="digital identity">request protocol</dfn>
+        <dfn for="digital credential">request protocol</dfn>
       </dt>
       <dd>
-        The request protocol is a standardized format/structure to [=request
-        digital identity credentials=]. For example, a request protocol could
-        be a <a>"mdoc"</a> for mobile driver's licenses as per
-        [[?ISO-18013-5]].
+        The request protocol is a standardized format/structure to [=request a
+        digital credential=]. For example, a request protocol could be a
+        `"some-format"` to request a driver's licenses.
       </dd>
     </dl>
     <h2>
@@ -111,7 +109,7 @@
       The following is in is scope for the this specification:
     </p>
     <ul>
-      <li>Requesting a [=digital identity credentials=].
+      <li>Requesting a [=digital credentials=].
       </li>
     </ul>
     <p>
@@ -119,12 +117,18 @@
     </p>
     <ul>
       <li>Creating, updating, deleting, or otherwise managing [=digital
-      identity credentials=].
+      credentials=].
       </li>
     </ul>
     <h2>
-      Extensions to the `CredentialsContainer` interface
+      Extensions to Credential Management API
     </h2>
+    <p>
+      ...coming soon...
+    </p>
+    <h3>
+      Extensions to the `CredentialsContainer` interface
+    </h3>
     <pre class="idl">
     partial interface CredentialsContainer {
       Promise&lt;DigitalCredential&gt; requestIdentity(DigitalCredentialRequestOptions options);
@@ -135,14 +139,14 @@
     </h3>
     <p data-dfn-for="CredentialsContainer">
       When the <dfn>requestIdentity()</dfn> method is called, the user agent
-      MUST run the [=request digital identity credentials=] steps.
+      MUST run the [=request a digital credential=] steps.
     </p>
     <h2>
-      The `IdentityRequestOptions` dictionary
+      The `DigitalCredentialRequestOptions` dictionary
     </h2>
     <p>
-      The {{IdentityRequestOptions}} dictionary is used to specify options when
-      requesting a digital identity credential.
+      The {{DigitalCredentialRequestOptions}} dictionary is used to specify
+      options when requesting a digital identity credential.
     </p>
     <pre class="idl">
     dictionary DigitalCredentialRequestOptions {
@@ -151,16 +155,17 @@
     };
     </pre>
     <p>
-      The <dfn data-dfn-for="IdentityRequestOptions">providers</dfn> member is
-      a sequence of [=digital credential/request protocol=] specific providers.
+      The <dfn data-dfn-for="DigitalCredentialRequestOptions">providers</dfn>
+      member is a sequence of [=digital credential/request protocol=] specific
+      providers.
     </p>
     <h3>
       The `signal` member
     </h3>
     <p>
-      The <dfn data-dfn-for="IdentityRequestOptions">signal</dfn> member is an
-      {{AbortSignal}} that allows the caller to abort an ongoing [=request
-      digital identity credentials=].
+      The <dfn data-dfn-for="DigitalCredentialRequestOptions">signal</dfn>
+      member is an {{AbortSignal}} that allows the caller to abort an ongoing
+      [=request a digital credential=].
     </p>
     <h2>
       The `IdentityRequestProvider` dictionary
@@ -194,21 +199,21 @@
     </h3>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">request</dfn> member is
-      the request to be sent to the [=identity credential provider=].
+      the request to be sent to the [=credential provider=].
     </p>
     <h3>
       The `publicKey` member
     </h3>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">publicKey</dfn> member is
-      the public key of the [=identity credential provider=].
+      the public key of the [=credential provider=].
     </p>
     <h2>
       Requesting a digital identity credential
     </h2>
     <p>
-      The following steps are taken to <dfn>request digital identity
-      credentials</dfn>, with {{IdentityRequestOptions}} |options|:
+      The following steps are taken to <dfn>request a digital credential</dfn>,
+      with {{DigitalCredentialRequestOptions}} |options|:
     </p>
     <ol>
       <li>Let |promise| be [=a new promise=].
@@ -217,21 +222,20 @@
       parallel=].
       </li>
       <li>For each |provider:IdentityRequestProvider| of |options|'s
-      {{IdentityRequestOptions/providers}}.
+      {{DigitalCredentialRequestOptions/providers}}.
         <ol>
           <li>[=verify the public key=] of |provider|.
           </li>
         </ol>
       </li>
-      <li>...present [=identity credential provider=] to user.
+      <li>...present [=credential provider=] to user.
       </li>
     </ol>
     <h2>
       The `DigitalCredential` interface
     </h2>
     <p>
-      The {{DigitalCredential}} interface represents a [=digital identity
-      credential=].
+      The {{DigitalCredential}} interface represents a [=digital credential=].
     </p>
     <pre class="idl">
     [Exposed=Window, SecureContext]
@@ -260,24 +264,42 @@
     </h2>
     <p>
       The following steps are taken to <dfn>verify the public key</dfn> of a
-      [=identity credential provider=], with {{CryptoKey}} |key|:
+      [=credential provider=], with {{CryptoKey}} |key|:
     </p>
     <ol>
-      <li>...restrictions on type, format, and usage of |key|...
+      <li>
+        <aside class="issue" data-number="56"></aside>
       </li>
     </ol>
     <h2 id="protocol-registry">
-      Identity Request Protocols Registry
+      Registry of protocols for requesting Digital Credential
     </h2>
     <p>
-      The following is the initial registry of [=digital credential/request
-      protocols=] that are supported by this specification.
+      The following is the registry of [=digital credential/request protocols=]
+      that are supported by this specification.
     </p>
+    <p class="note" title="Official Registry" data-cite="w3c-process">
+      It is expected that this registry will be become a [=W3C registry=] in
+      the future.
+    </p>
+    <h3>
+      Inclusion criteria
+    </h3>
     <p>
-      User agents MUST support the following [=digital credential/request
+      To be included in the registry...
+    </p>
+    <aside class="issue" data-number="58"></aside>
+    <h3>
+
+    </h3>
+    <p>
+      [=User agents=] MUST support the following [=digital credential/request
       protocols=]:
     </p>
     <table class="data">
+      <caption>
+        Table of officially registered [=digital credential/request protocols=].
+      </caption>
       <thead>
         <tr>
           <th>
@@ -293,14 +315,8 @@
       </thead>
       <tbody>
         <tr>
-          <td>
-            <code><dfn>"mdoc"</dfn></code>
-          </td>
-          <td>
-            A mobile driving license (mDL) request.
-          </td>
-          <td>
-            [[ISO-18013-5]]
+          <td colspan="3">
+            Coming soon...
           </td>
         </tr>
       </tbody>

--- a/index.html
+++ b/index.html
@@ -87,13 +87,13 @@
           about an individual's identity. Issued by a trusted [=digital
           identity/issuer=], it enables authenticated interactions.
         </p>
-        <aside class="Note">
-          [=Digital identities=] are represented as {{DigitalIdentity}}
-          instances.
+        <aside class="note">
+          [=Digital identities=] are represented as instances of the
+          {{DigitalIdentity}} interface.
         </aside>
       </dd>
       <dt>
-        <dfn>Identity credential chooser</dfn>
+        <dfn>Identity credential provider</dfn>
       </dt>
       <dd>
         An application or service that provides a user interface for selecting
@@ -106,7 +106,7 @@
       <dd>
         A standardized format for requesting a [=digital identity=], designed
         to ensure the secure, private, and interoperable exchange of identity
-        information. See [[#protocol-registry]].
+        information. See section [[[#protocol-registry]]].
       </dd>
       <dt>
         <dfn data-for="Digital identity">Issuer</dfn>
@@ -158,28 +158,29 @@
     </h3>
     <aside class="issue" data-number="65"></aside>
     <h2>
-       Extensions to `CredentialRequestOptions` dictionary
+      Extensions to `CredentialRequestOptions` dictionary
     </h2>
     <pre class="idl">
     partial dictionary CredentialRequestOptions {
-     sequence&lt;IdentityRequestProvider&gt; providers;
+      sequence&lt;IdentityRequestProvider&gt; providers;
     };
     </pre>
     <h3>
       The `providers` member
     </h3>
     <p>
-      The <dfn data-dfn-for="CredentialRequestOptions">providers</dfn>
-      member is a sequence of [=digital identity/request protocol=] specific
-      providers.
+      The <dfn data-dfn-for="CredentialRequestOptions">providers</dfn> member
+      is a sequence of [=digital identity/request protocol=] that can
+      potentially be handled by a user's selected [=identity credential
+      provider=].
     </p>
     <h2>
       The `IdentityRequestProvider` dictionary
     </h2>
     <p>
       The {{IdentityRequestProvider}} dictionary is used to specify a [=digital
-      identity/request protocol=] specific provider, while also handling
-      cryptographic requirements.
+      identity/request protocol=] and structured request, which the user agent
+      MAY match against a [=identity credential provider=].
     </p>
     <pre class="idl">
     dictionary IdentityRequestProvider {
@@ -204,13 +205,15 @@
     </h3>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">request</dfn> member is
-      the request to be sent to the [=identity credential chooser=].
+      the request to be handled by the user's selected [=identity credential
+      provider=].
     </p>
     <h2>
       The `Identity` interface
     </h2>
     <p>
-      The <dfn>Identity</dfn> interface represents an [=identity credential=].
+      The <dfn>Identity</dfn> interface is used in the API to represent
+      [=credentials=] that are classified as an [=identity credential=].
     </p>
     <pre class="idl">
       [Exposed=Window]

--- a/index.html
+++ b/index.html
@@ -131,7 +131,9 @@
     </h3>
     <pre class="idl">
     partial interface CredentialsContainer {
-      Promise&lt;DigitalCredential&gt; requestIdentity(DigitalCredentialRequestOptions options);
+      Promise&lt;DigitalCredential&gt; requestIdentity(
+        DigitalCredentialRequestOptions options
+      );
     };
     </pre>
     <h3>

--- a/index.html
+++ b/index.html
@@ -182,7 +182,6 @@
     dictionary IdentityRequestProvider {
       required DOMString protocol;
       required ArrayBuffer request;
-      required CryptoKey publicKey;
     };
     </pre>
     <h3>
@@ -204,14 +203,6 @@
       The <dfn data-dfn-for="IdentityRequestProvider">request</dfn> member is
       the request to be sent to the [=credential provider=].
     </p>
-    <h3>
-      The `publicKey` member
-    </h3>
-    <aside class="issue" data-number="49"></aside>
-    <p>
-      The <dfn data-dfn-for="IdentityRequestProvider">publicKey</dfn> member is
-      the public key of the [=credential provider=].
-    </p>
     <h2>
       Requesting a digital identity credential
     </h2>
@@ -228,7 +219,7 @@
       <li>For each |provider:IdentityRequestProvider| of |options|'s
       {{DigitalCredentialRequestOptions/providers}}.
         <ol>
-          <li>[=verify the public key=] of |provider|.
+          <li>...process provider...
           </li>
         </ol>
       </li>
@@ -262,13 +253,6 @@
     <p>
       The <dfn data-dfn-for="DigitalCredential">data</dfn> member is the
       credential's encrypted data.
-    </p>
-    <h2>
-      Public key verification
-    </h2>
-    <p>
-      The following steps are taken to <dfn>verify the public key</dfn> of a
-      [=credential provider=], with {{CryptoKey}} |key|:
     </p>
     <ol>
       <li>

--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
       The `providers` member
     </h3>
     <p>
-      The <dfn data-dfn-for="DigitalIdentityRequestOptions">providers</dfn>
+      The <dfn data-dfn-for="CredentialRequestOptions">providers</dfn>
       member is a sequence of [=digital identity/request protocol=] specific
       providers.
     </p>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
         <p>
           A credential provider is a an application or OS-level service that
           presents UI to the user to request a [=digital credential=]. For
-          example,s a credential provider could be a mobile wallet application
+          example, a credential provider could be a mobile wallet application
           that requests a mobile driver's license from the user.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
       requesting a digital identity credential.
     </p>
     <pre class="idl">
-    dictionary IdentityRequestOptions {
+    dictionary DigitalCredentialRequestOptions {
       AbortSignal signal;
       required sequence&lt;IdentityRequestProvider&gt; providers;
     };

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     <section id="abstract">
       <p>
         This document specifies an API solution for requesting digital
-        identity credentials (e.g., a drivers license) or verifying some aspect
+        identity credentials (e.g. a drivers license) or verifying some aspect
         of a digital identity credential (e.g., proof of age). The API builds
         on the [[[credential-management-1]]] as a means to request a digital
         credential from the user agent or underlying platform.

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
       <dd>
         <p>
           A specialized type of [=credential=] corresponding to the real-world
-          identity of a person enabling developers to make authentication
+          identity of a person enabling a [=verifier=] to make authentication
           decisions based on identity statements verifiably made by an [=issuer=].
         </p>
         <aside class="Note">

--- a/tidyconfig.txt
+++ b/tidyconfig.txt
@@ -1,0 +1,6 @@
+char-encoding: utf8
+indent: yes
+indent-spaces: 2
+wrap: 80
+tidy-mark: no
+custom-tags: yes


### PR DESCRIPTION
Adds the initial spec based on [latest proposal](https://github.com/WICG/identity-credential/blob/main/digital-credentials-2-proposal.md).

closes #61


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 3, 2024, 12:42 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fdigital-credentials%2F06d9a61d1e82545e5fcdf2d9e27daaddd080a78c%2Findex.html%3Fforce%3D1%26isPreview%3Dtrue)

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/digital-credentials%2357.)._
</details>
