### PR TITLE
Add scoping language related to matching and consent.

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
       anything about the a holder's [=digital credentials=] or their software
       unless the [=user agent=] has previously received user consent.
       </li>
-      <li>Ensuring that any non-[=user agent=] software will not learn anything
+      <li>Ensuring that any installed application software will not learn anything
       about a given [=request=] unless the [=holder=] explicitly consents to use that
       software.
       </li>

--- a/index.html
+++ b/index.html
@@ -114,10 +114,10 @@
       </li>
       <li>Ensuring that when an API call is made, the website does not learn
       anything about the a holder's [=digital credentials=] or their software
-      unless the [=user agent=] has gained explicit user consent.
+      unless the [=user agent=] has express user consent.
       </li>
       <li>Ensuring that any non-[=user agent=] software will not learn anything
-      about a given request unless the holder explicitly consents to use the
+      about a given [=request=] unless the [=holder=] explicitly consents to use that
       software.
       </li>
     </ul>

--- a/index.html
+++ b/index.html
@@ -112,6 +112,14 @@
       <li>Requesting a [=digital credential=], including mechanisms for secure
       presentation.
       </li>
+      <li>Ensuring that when an API call is made, the website does not learn
+      anything about the a holder's [=digital credentials=] or their software
+      unless the [=user agent=] has gained explicit user consent.
+      </li>
+      <li>Ensuring that any non-[=user agent=] software will not learn anything
+      about a given request unless the holder explicitly consents to use the
+      software.
+      </li>
     </ul>
     <p>
       The following items are out of scope:

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
       </li>
       <li>Ensuring that when an API call is made, the website does not learn
       anything about the a holder's [=digital credentials=] or their software
-      unless the [=user agent=] has express user consent.
+      unless the [=user agent=] has previously received user consent.
       </li>
       <li>Ensuring that any non-[=user agent=] software will not learn anything
       about a given [=request=] unless the [=holder=] explicitly consents to use that


### PR DESCRIPTION
Closes #86 by asserting scoping around matching, consent, and what is learned by a website and 3rd party software.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/msporny/digital-identities/pull/89.html" title="Last updated on Aug 26, 2024, 10:40 PM UTC (de6afd4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/digital-credentials/89/292a71a...msporny:de6afd4.html" title="Last updated on Aug 26, 2024, 10:40 PM UTC (de6afd4)">Diff</a>