### PR TITLE
Use SecurityError for document state check

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@
       </li>
       <li>If |document| is not a [=Document/fully active descendant of a
       top-level traversable with user attention=], [=exception/throw=]
-      {{"NotAllowedError"}} {{DOMException}}.
+      {{"SecurityError"}} {{DOMException}}.
       </li>
       <li>If |window| does not have [=transient activation=],
       [=exception/throw=] {{"NotAllowedError"}} {{DOMException}}.


### PR DESCRIPTION
We currently have an over-reliance on NotAllowedError. This makes things a bit more distinguishable, and lets developers know a bit more about what's going on. 


The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
 
