### PR TITLE
Throw NotSupported for Store

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,14 +322,12 @@
       The {{Credential/[[Store]](credential, sameOriginWithAncestors)}} method is not supported for the {{DigitalCredential}} type, 
       so its implementation of the {{Credential/[[Store]](credential, sameOriginWithAncestors)}} internal method always throws an error.
     </p>
-    <p></p>
+    <p>
       When this method is invoked, the user agent MUST execute the following algorithm:
-      
+    </p>      
       <ol>
         <li>Throw a {{"NotSupportedError"}} {{DOMException}}.</li>
       </ol>
-
-    </p>
     <h3>
       [[\Create]](origin, options, sameOriginWithAncestors) internal method
     </h3>

--- a/index.html
+++ b/index.html
@@ -319,11 +319,18 @@
       [[\Store]](credential, sameOriginWithAncestors) internal method
     </h3>
     <p>
-      When invoked, the <dfn class="export" data-dfn-for=
+      The <dfn class="export" data-dfn-for=
       "DigitalCredential">[[\Store]](credential, sameOriginWithAncestors)</dfn>
-      MUST call the default implementation of {{Credential}}'s
-      {{Credential/[[Store]](credential, sameOriginWithAncestors)}} internal
-      method with the same arguments.
+      method is not supported for the {{DigitalCredential}} type, so its implementation of the 
+      {{Credential/[[Store]](credential, sameOriginWithAncestors)}} internal method always throws an error.
+    </p>
+    <p></p>
+      When this method is invoked, the user agent MUST execute the following algorithm:
+      
+      <ol>
+        <li>Throw a {{"NotSupportedError"}} {{DOMException}}.</li>
+      </ol>
+
     </p>
     <h3>
       [[\Create]](origin, options, sameOriginWithAncestors) internal method

--- a/index.html
+++ b/index.html
@@ -319,11 +319,9 @@
       [[\Store]](credential, sameOriginWithAncestors) internal method
     </h3>
     <p>
-      The {{Credential/[[Store]](credential, sameOriginWithAncestors)}} method is not supported for the {{DigitalCredential}} type, 
-      so its implementation of the {{Credential/[[Store]](credential, sameOriginWithAncestors)}} internal method always throws an error.
-    </p>
-    <p>
-      When this method is invoked, the user agent MUST execute the following algorithm:
+       When invoked, the <dfn class="export" data-dfn-for=
+      "DigitalCredential">[[\Store]](credential, sameOriginWithAncestors)</dfn>
+      MUST:
     </p>      
       <ol>
         <li>Throw a {{"NotSupportedError"}} {{DOMException}}.</li>

--- a/index.html
+++ b/index.html
@@ -321,11 +321,8 @@
     <p>
       When invoked, the <dfn class="export" data-dfn-for=
       "DigitalCredential">[[\Store]](credential, sameOriginWithAncestors)</dfn>
-      MUST:
-    </p>      
-    <ol>
-      <li>Throw a {{"NotSupportedError"}} {{DOMException}}.</li>
-    </ol>
+      MUST throw a {{"NotSupportedError"}} {{DOMException}}.
+    </p>
     <h3>
       [[\Create]](origin, options, sameOriginWithAncestors) internal method
     </h3>

--- a/index.html
+++ b/index.html
@@ -319,10 +319,8 @@
       [[\Store]](credential, sameOriginWithAncestors) internal method
     </h3>
     <p>
-      The <dfn class="export" data-dfn-for=
-      "DigitalCredential">[[\Store]](credential, sameOriginWithAncestors)</dfn>
-      method is not supported for the {{DigitalCredential}} type, so its implementation of the 
-      {{Credential/[[Store]](credential, sameOriginWithAncestors)}} internal method always throws an error.
+      The {{Credential/[[Store]](credential, sameOriginWithAncestors)}} method is not supported for the {{DigitalCredential}} type, 
+      so its implementation of the {{Credential/[[Store]](credential, sameOriginWithAncestors)}} internal method always throws an error.
     </p>
     <p></p>
       When this method is invoked, the user agent MUST execute the following algorithm:

--- a/index.html
+++ b/index.html
@@ -319,13 +319,13 @@
       [[\Store]](credential, sameOriginWithAncestors) internal method
     </h3>
     <p>
-       When invoked, the <dfn class="export" data-dfn-for=
+      When invoked, the <dfn class="export" data-dfn-for=
       "DigitalCredential">[[\Store]](credential, sameOriginWithAncestors)</dfn>
       MUST:
     </p>      
-      <ol>
-        <li>Throw a {{"NotSupportedError"}} {{DOMException}}.</li>
-      </ol>
+    <ol>
+      <li>Throw a {{"NotSupportedError"}} {{DOMException}}.</li>
+    </ol>
     <h3>
       [[\Create]](origin, options, sameOriginWithAncestors) internal method
     </h3>


### PR DESCRIPTION
The Store method isn't used for Digital Credentials. Throw `NotSupportedError` if called.

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/digital-credentials/pull/158.html" title="Last updated on Aug 13, 2024, 7:15 AM UTC (8da50b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/digital-credentials/158/4a4a43b...8da50b4.html" title="Last updated on Aug 13, 2024, 7:15 AM UTC (8da50b4)">Diff</a>