### PR TITLE
Allow mediation="optional"

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         license, government-issued identification card, and/or [=credential
         type examples|other types of digital credential=]. The API builds on
         [[[credential-management-1]]] as a means by which to request a digital
-        credential from a user agent or underlying platform.
+        credential from a user agent or underlying platform. 
       </p>
     </section>
     <section id="sotd">
@@ -240,13 +240,12 @@
     </p>
     <p>
       [=User mediation=] is always
-      {{CredentialMediationRequirement/"required"}}. [=Request a
+      {{CredentialMediationRequirement/"required"}} or {{CredentialMediationRequirement/"optional"}}. [=Request a
       credential|Requesting a DigitalCredential credential=] does not support
-      {{CredentialMediationRequirement/"conditional"}},
-      {{CredentialMediationRequirement/"optional"}}, or
+      {{CredentialMediationRequirement/"conditional"}} or
       {{CredentialMediationRequirement/"silent"}} [=user mediation=]. If
       {{CredentialsContainer/get()}} is called with anything other than
-      {{CredentialMediationRequirement/"required"}}, a {{TypeError}} will be
+      {{CredentialMediationRequirement/"required"}} or {{CredentialMediationRequirement/"optional"}}, a {{TypeError}} will be
       thrown.
     </p>
     <pre class="idl">


### PR DESCRIPTION
From an implementation perspective, the user agent can always take mediation = "optional" as mediation = "required".

There are two reasons to accept mediation = "optional" too:

(a) first, it is the default value of `mediation`, so it allows an unspecified mediation to fallback to something runnable (b) second, it allows implementations to take the hint from developers and experiment with ways in which the [user mediation](https://www.w3.org/TR/credential-management-1/#dom-credentialmediationrequirement-optional) can be waived (e.g. on a subsequent presentation).

Closes #175

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/digital-credentials/pull/176.html" title="Last updated on Oct 7, 2024, 3:38 PM UTC (8e20d3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/digital-credentials/176/fa29b9f...8e20d3b.html" title="Last updated on Oct 7, 2024, 3:38 PM UTC (8e20d3b)">Diff</a>