### PR TITLE
chore: update short name to "digital-credentials" 

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         // https://github.com/w3c/respec/wiki/editors
       ],
       latestVersion: null,
-      shortName: "digital-identity",
+      shortName: "digital-credentials",
       specStatus: "CG-DRAFT",
       group: "wicg",
       localBiblio: {},


### PR DESCRIPTION
s/digital-identity/digital-credentials


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/digital-credentials/pull/180.html" title="Last updated on Oct 8, 2024, 2:56 PM UTC (4eff5c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/digital-credentials/180/3d86917...4eff5c7.html" title="Last updated on Oct 8, 2024, 2:56 PM UTC (4eff5c7)">Diff</a>