### PR TITLE
DigitalCredential's data should be marked at SameObject

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
     [Exposed=Window, SecureContext]
     interface DigitalCredential : Credential {
       readonly attribute DOMString protocol;
-      readonly attribute object data;
+      [SameObject] readonly attribute object data;
     };
     </pre>
     <p>


### PR DESCRIPTION
This is mostly just a small optimization, but the .data should have been marked as SameObject, as it never changes.

The following tasks have been completed:

- [X] Modified Web platform tests - automatic (but it's not detectable). 

Implementation commitment:

- [x] WebKit - already implemented. 
- [x] Chromium (link to [issue](https://g-issues.chromium.org/issues/390257842))
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/digital-credentials/pull/199.html" title="Last updated on Jan 15, 2025, 11:53 PM UTC (3be0326)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/digital-credentials/199/9b414ea...3be0326.html" title="Last updated on Jan 15, 2025, 11:53 PM UTC (3be0326)">Diff</a>